### PR TITLE
Updates to the latest SDK with passkeys that use credential manager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ android {
 }
 
 dependencies {
-    implementation("se.curity.identityserver:identityserver.haapi.android.ui.widget:4.3.0")
+    implementation("se.curity.identityserver:identityserver.haapi.android.ui.widget:4.4.0")
 
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.0")

--- a/app/src/main/java/io/curity/haapidemo/Configuration.kt
+++ b/app/src/main/java/io/curity/haapidemo/Configuration.kt
@@ -56,7 +56,7 @@ data class Configuration(
 
     init {
         HaapiLogger.enabled = true
-        HaapiLogger.isDebugEnabled = false
+        HaapiLogger.setLevel(HaapiLogger.LogLevel.INFO)
     }
 
     companion object {

--- a/app/src/main/java/io/curity/haapidemo/DemoApplication.kt
+++ b/app/src/main/java/io/curity/haapidemo/DemoApplication.kt
@@ -5,7 +5,6 @@ import io.curity.haapidemo.utils.SharedPreferenceStorage
 import io.curity.haapidemo.utils.disableSslTrustVerification
 import se.curity.identityserver.haapi.android.driver.KeyPairAlgorithmConfig
 import se.curity.identityserver.haapi.android.driver.TokenBoundConfiguration
-import se.curity.identityserver.haapi.android.sdk.util.ExperimentalWebAuthnApi
 import se.curity.identityserver.haapi.android.ui.widget.HaapiUIWidgetApplication
 import se.curity.identityserver.haapi.android.ui.widget.WidgetConfiguration
 import java.net.HttpURLConnection
@@ -14,7 +13,6 @@ import java.net.URI
 class DemoApplication: Application(), HaapiUIWidgetApplication {
     val configuration = Configuration.newInstance()
 
-    @OptIn(ExperimentalWebAuthnApi::class)
     private val haapiWidgetConfiguration = run {
 
         val baseUri = URI(configuration.baseURLString)
@@ -25,7 +23,6 @@ class DemoApplication: Application(), HaapiUIWidgetApplication {
             authorizationEndpointUri = baseUri.resolve(configuration.authorizationEndpointPath),
             appRedirect = configuration.redirectURI,
         )
-            .setUseNativeWebAuthnSupport(true)
             .setTokenBoundConfiguration(createTokenBoundConfiguration())
             .setOauthAuthorizationParamsProvider {
                 WidgetConfiguration.OAuthAuthorizationParams(


### PR DESCRIPTION
- Remove retired experimental support for native passkeys
- Use newer logging API since the old one is deprecated