### PR TITLE
Use latest 4.5.0 SDK and rename the attestation policy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ android {
 }
 
 dependencies {
-    implementation("se.curity.identityserver:identityserver.haapi.android.ui.widget:4.4.0")
+    implementation("se.curity.identityserver:identityserver.haapi.android.ui.widget:4.5.0")
 
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")

--- a/config/docker-template.xml
+++ b/config/docker-template.xml
@@ -84,7 +84,7 @@
                                     <android>
                                         <package-name>io.curity.haapidemo</package-name>
                                         <signature-digest>Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ=</signature-digest>
-                                        <android-policy>android-dev-policy</android-policy>
+                                        <android-policy>android-policy</android-policy>
                                     </android>
                                 </attestation>
                             </client>
@@ -97,7 +97,7 @@
     <facilities xmlns="https://curity.se/ns/conf/base">
         <client-attestation>
             <android-policy xmlns="https://curity.se/ns/conf/client-attestation">
-                <id>android-dev-policy</id>
+                <id>android-policy</id>
                 <verify-boot-state>false</verify-boot-state>
                 <minimum-security-level>software</minimum-security-level>
                 <override-certificate-chain-validation>


### PR DESCRIPTION
You can deploy and edit the attestation policy to use real devices. 
Therefore I also made a minor rename from **android-dev-policy** to **android-policy**.